### PR TITLE
Added food recipes

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -28,6 +28,7 @@
 - Adds social impact buff to bigger breasts and penises.
 - Removes natural and bionic body part debuffs (not hydraulic/peg as they are supposed to be worse).
 - Makes humpshroom less painful to grow and makes it possible to grow it on the ground and in light.
+- Removes cum, humpshroom and condoms from default selection for most meals
 
 Thanks to Tory187 and Abraxas for the help in the makings.
 Merged XenoMorphie's merge request i missed by a whole year which supposedly fixes errors with socialimpact for archotech bits.

--- a/Patches/RecipePatches.xml
+++ b/Patches/RecipePatches.xml
@@ -1,0 +1,68 @@
+<Patch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/RecipeDef[@Name="CookMealBase"]/defaultIngredientFilter/disallowedThingDefs</xpath>
+		<value>
+			<li MayRequire="rjw.sexperience">GatheredCum</li>
+			<li MayRequire="rim.job.world">UsedCondom</li>
+			<li MayRequire="rim.job.world">HumpShroom</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="Make_BabyFood" or defName="Make_BabyFoodBulk"]/fixedIngredientFilter</xpath>
+		<value>
+			<disallowedThingDefs>
+				<li MayRequire="rjw.sexperience">GatheredCum</li>
+				<li MayRequire="rim.job.world">UsedCondom</li>
+				<li MayRequire="rim.job.world">HumpShroom</li>
+			</disallowedThingDefs>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/RecipeDef[defName="Make_Kibble"]/defaultIngredientFilter/disallowedThingDefs</xpath>
+		<value>
+			<li MayRequire="rjw.sexperience">GatheredCum</li>
+			<li MayRequire="rim.job.world">UsedCondom</li>
+			<li MayRequire="rim.job.world">HumpShroom</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/RecipeDef[defName="Make_Pemmican" or defName="Make_PemmicanBulk"]/defaultIngredientFilter/disallowedThingDefs</xpath>
+		<value>
+			<li MayRequire="rim.job.world">HumpShroom</li>
+		</value>
+	</Operation>
+	
+	<!-- Vanilla Expanded recipes -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Cooking Expanded</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+			<xpath>/Defs/RecipeDef[@Name="CookGourmetMealBase" or @Name="VCE_CookBakeMealBase" or @Name="VCE_CookGourmetBakeMealBase" or @Name="VCE_CookDessertMealBase" or @Name="VCE_CookComplexDessertMealBase" or @Name="VCE_CookGourmetDessertMealBase"]/defaultIngredientFilter/disallowedThingDefs</xpath>
+			<value>
+				<li MayRequire="rjw.sexperience">GatheredCum</li>
+				<li MayRequire="rim.job.world">UsedCondom</li>
+				<li MayRequire="rim.job.world">HumpShroom</li>
+			</value>
+		</match>
+	</Operation>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Cooking Expanded - Sushi</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+			<xpath>/Defs/RecipeDef[@Name="VCE_CookSushiMealBase" or @Name="VCE_CookFineSushiMealBase" or @Name="VCE_CookGourmetSushiMealBase"]/defaultIngredientFilter</xpath>
+			<value>
+				<disallowedThingDefs>
+					<li MayRequire="rjw.sexperience">GatheredCum</li>
+					<li MayRequire="rim.job.world">UsedCondom</li>
+					<li MayRequire="rim.job.world">HumpShroom</li>
+				</disallowedThingDefs>
+			</value>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Add the recipe patch to remove default cum ingredients to help with big modded food modlists (to stop pawns from getting the Ate Cum debuff all the time on accident as well as stopping them from using the shrooms for cooking instead of making medicines/drugs)

Removes from all the meals derived from the vanilla meals, pemmican, baby food, kibble, as well as from the gourment ones and sushi from Vanilla Expanded.